### PR TITLE
Market fee events

### DIFF
--- a/contracts/Markets/Market.sol
+++ b/contracts/Markets/Market.sol
@@ -12,8 +12,8 @@ contract Market {
     event MarketFunding(uint funding);
     event MarketClosing();
     event FeeWithdrawal(uint fees);
-    event OutcomeTokenPurchase(address indexed buyer, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint cost);
-    event OutcomeTokenSale(address indexed seller, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint profit);
+    event OutcomeTokenPurchase(address indexed buyer, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint outcomeTokenCost, uint marketFees);
+    event OutcomeTokenSale(address indexed seller, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint outcomeTokenProfit, uint marketFees);
     event OutcomeTokenShortSale(address indexed buyer, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint cost);
 
     /*

--- a/contracts/Markets/StandardMarket.sol
+++ b/contracts/Markets/StandardMarket.sol
@@ -150,7 +150,7 @@ contract StandardMarket is Market {
         // Subtract outcome token count from market maker net balance
         require(int(outcomeTokenCount) >= 0);
         netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].sub(int(outcomeTokenCount));
-        OutcomeTokenSale(msg.sender, outcomeTokenIndex, outcomeTokenCount, profit, fees);
+        OutcomeTokenSale(msg.sender, outcomeTokenIndex, outcomeTokenCount, outcomeTokenProfit, fees);
     }
 
     /// @dev Buys all outcomes, then sells all shares of selected outcome which were bought, keeping

--- a/contracts/Markets/StandardMarket.sol
+++ b/contracts/Markets/StandardMarket.sol
@@ -121,7 +121,7 @@ contract StandardMarket is Market {
         // Add outcome token count to market maker net balance
         require(int(outcomeTokenCount) >= 0);
         netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].add(int(outcomeTokenCount));
-        OutcomeTokenPurchase(msg.sender, outcomeTokenIndex, outcomeTokenCount, cost);
+        OutcomeTokenPurchase(msg.sender, outcomeTokenIndex, outcomeTokenCount, outcomeTokenCost, fees);
     }
 
     /// @dev Allows to sell outcome tokens to market maker
@@ -150,7 +150,7 @@ contract StandardMarket is Market {
         // Subtract outcome token count from market maker net balance
         require(int(outcomeTokenCount) >= 0);
         netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].sub(int(outcomeTokenCount));
-        OutcomeTokenSale(msg.sender, outcomeTokenIndex, outcomeTokenCount, profit);
+        OutcomeTokenSale(msg.sender, outcomeTokenIndex, outcomeTokenCount, profit, fees);
     }
 
     /// @dev Buys all outcomes, then sells all shares of selected outcome which were bought, keeping

--- a/test/javascript/test_market_makers.js
+++ b/test/javascript/test_market_makers.js
@@ -79,7 +79,7 @@ contract('MarketMaker', function(accounts) {
             // Selling tokens
             await outcomeToken.approve(market.address, tokenCount, { from: accounts[trader] })
             assert.equal(getParamFromTxEvent(
-                await market.sell(outcome, tokenCount, profit, { from: accounts[trader] }), 'profit'
+                await market.sell(outcome, tokenCount, profit, { from: accounts[trader] }), 'outcomeTokenProfit'
             ).valueOf(), profit.valueOf())
 
             let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))
@@ -146,7 +146,7 @@ contract('MarketMaker', function(accounts) {
                 // Buying tokens
                 await etherToken.approve(market.address, tokenCount, { from: accounts[trader] })
                 assert.equal(getParamFromTxEvent(
-                    await market.buy(outcome, tokenCount, cost, { from: accounts[trader] }), 'cost'
+                    await market.buy(outcome, tokenCount, cost, { from: accounts[trader] }), 'outcomeTokenCost'
                 ).valueOf(), cost.valueOf())
 
                 let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))

--- a/test/javascript/test_markets.js
+++ b/test/javascript/test_markets.js
@@ -117,8 +117,8 @@ contract('Market', function (accounts) {
 
         await etherToken.approve(market.address, cost, { from: accounts[buyer] })
         assert.equal(getParamFromTxEvent(
-            await market.buy(outcome, tokenCount, cost, { from: accounts[buyer] }), 'cost'
-        ), cost.valueOf())
+            await market.buy(outcome, tokenCount, cost, { from: accounts[buyer] }), 'outcomeTokenCost'
+        ), outcomeTokenCost.valueOf())
 
         const outcomeToken = Token.at(await event.outcomeTokens(outcome))
         assert.equal(await outcomeToken.balanceOf(accounts[buyer]), tokenCount)
@@ -131,8 +131,8 @@ contract('Market', function (accounts) {
 
         await outcomeToken.approve(market.address, tokenCount, { from: accounts[buyer] })
         assert.equal(getParamFromTxEvent(
-            await market.sell(outcome, tokenCount, profit, { from: accounts[buyer] }), 'profit'
-        ), profit.valueOf())
+            await market.sell(outcome, tokenCount, profit, { from: accounts[buyer] }), 'outcomeTokenProfit'
+        ).valueOf(), outcomeTokenProfit.valueOf())
 
         assert.equal(await outcomeToken.balanceOf(accounts[buyer]), 0)
         assert.equal(await etherToken.balanceOf(accounts[buyer]), profit.valueOf())
@@ -233,8 +233,8 @@ contract('Market', function (accounts) {
 
         await etherToken.approve(market.address, cost, { from: accounts[buyer] })
         assert.equal(getParamFromTxEvent(
-            await market.buy(outcome, tokenCount, cost, { from: accounts[buyer] }), 'cost').valueOf()
-        , cost.valueOf())
+            await market.buy(outcome, tokenCount, cost, { from: accounts[buyer] }), 'outcomeTokenCost').valueOf()
+        , outcomeTokenCost.valueOf())
 
         // Set outcome
         await centralizedOracle.setOutcome(1)


### PR DESCRIPTION
Updated market sell/purchase events to include both outcome tokens price and related fee. This avoids calculation of cost on Gnosisdb.