### PR TITLE
Clamp instead of revert in limit subtraction

### DIFF
--- a/contracts/Oracles/UltimateOracle.sol
+++ b/contracts/Oracles/UltimateOracle.sol
@@ -107,7 +107,13 @@ contract UltimateOracle is Oracle {
     function voteForOutcome(int _outcome, uint amount)
         public
     {
-        uint maxAmount = (totalAmount - totalOutcomeAmounts[_outcome]).mul(spreadMultiplier).sub(totalOutcomeAmounts[_outcome]);
+        uint maxAmount = (totalAmount - totalOutcomeAmounts[_outcome]).mul(spreadMultiplier);
+
+        if (maxAmount > totalOutcomeAmounts[_outcome])
+            maxAmount -= totalOutcomeAmounts[_outcome];
+        else
+            maxAmount = 0;
+
         if (amount > maxAmount)
             amount = maxAmount;
         // Outcome is challenged and front runner period is not over yet and tokens can be transferred

--- a/test/javascript/test_oracles.js
+++ b/test/javascript/test_oracles.js
@@ -151,9 +151,8 @@ contract('Oracle', function (accounts) {
         // Sender 1 tries to increase their bid but can't
         await etherToken.deposit({value: 50, from: accounts[sender1]})
         await etherToken.approve(ultimateOracle.address, 50, { from: accounts[sender1] })
-        await utils.assertRejects(
-            ultimateOracle.voteForOutcome(2, 50, { from: accounts[sender1] }),
-            'increase leading vote after challenge')
+        await ultimateOracle.voteForOutcome(2, 50, { from: accounts[sender1] })
+        assert.equal(await ultimateOracle.outcomeAmounts(accounts[sender1], 2), 100)
 
         // Sender 2 overbids sender 1
         const sender2 = 1


### PR DESCRIPTION
I feel this would be more consistent because counterbids are clamped instead of reverted.