### PR TITLE
Std market w price 2

### DIFF
--- a/contracts/Markets/StandardMarketWithPriceLogger.sol
+++ b/contracts/Markets/StandardMarketWithPriceLogger.sol
@@ -32,6 +32,8 @@ contract StandardMarketWithPriceLogger is StandardMarket {
         public
         StandardMarket(_creator, _eventContract, _marketMaker, _fee)
     {
+        require(eventContract.getOutcomeCount() == 2);
+
         if (_startDate == 0)
             startDate = now;
         else {
@@ -42,7 +44,7 @@ contract StandardMarketWithPriceLogger is StandardMarket {
 
         lastTradeDate = startDate;
         // initialize lastTradePrice to assuming uniform probabilities of outcomes
-        lastTradePrice = ONE / eventContract.getOutcomeCount();
+        lastTradePrice = ONE / 2;
     }
 
     /// @dev Allows market creator to close the markets by transferring all remaining outcome tokens to the creator

--- a/contracts/Oracles/FutarchyOracleFactory.sol
+++ b/contracts/Oracles/FutarchyOracleFactory.sol
@@ -19,7 +19,7 @@ contract FutarchyOracleFactory {
         int upperBound,
         MarketMaker marketMaker,
         uint24 fee,
-        uint deadline,
+        uint tradingPeriod,
         uint startDate
     );
 
@@ -51,7 +51,7 @@ contract FutarchyOracleFactory {
     /// @param upperBound Lower bound for event outcome
     /// @param marketMaker Market maker contract
     /// @param fee Market fee
-    /// @param deadline Decision deadline
+    /// @param tradingPeriod Trading period before decision can be determined
     /// @param startDate Start date for price logging
     /// @return Oracle contract
     function createFutarchyOracle(
@@ -62,7 +62,7 @@ contract FutarchyOracleFactory {
         int upperBound,
         MarketMaker marketMaker,
         uint24 fee,
-        uint deadline,
+        uint tradingPeriod,
         uint startDate
     )
         public
@@ -79,7 +79,7 @@ contract FutarchyOracleFactory {
             marketFactory,
             marketMaker,
             fee,
-            deadline,
+            tradingPeriod,
             startDate
         );
         FutarchyOracleCreation(
@@ -92,7 +92,7 @@ contract FutarchyOracleFactory {
             upperBound,
             marketMaker,
             fee,
-            deadline,
+            tradingPeriod,
             startDate
         );
     }


### PR DESCRIPTION
The implementation strategy for optimizing the average price getter was to split the logger into pre and post transaction calls and cache the calcMarginalCost calculation in a state variable.

I also require outcome count to be 2. This commit can be removed if it doesn't make sense.