### PR TITLE
Upgrade coverage tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3365,9 +3365,9 @@
       }
     },
     "solidity-coverage": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.3.5.tgz",
-      "integrity": "sha512-ZAzYfC9FVix3iqBbJyYow6EPxZevkUlEp0mjJ7b1bM7HWFjoPeoUowUq7nbYECP9WVOElakX6GLewJsIQern5w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.4.2.tgz",
+      "integrity": "sha512-nxkKsI1x/SGHI6dlhFgm82arpjL/6zfYVnYBQzC69nTrgKubtdGGd8Hm79gWKygn3N4NWFNKy36NMWDeyIFoDw==",
       "dev": true,
       "requires": {
         "death": "1.1.0",
@@ -3460,15 +3460,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3494,6 +3485,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.4",
     "npm-prepublish": "^1.2.3",
     "run-with-testrpc": "^0.3.0",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "^0.4.2",
     "truffle": "^3.4.11"
   },
   "repository": {

--- a/test/javascript/test_events.js
+++ b/test/javascript/test_events.js
@@ -40,24 +40,24 @@ contract('Event', function (accounts) {
         const buyer = 0
         const collateralTokenCount = 10
         await etherToken.deposit({ value: collateralTokenCount, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         await etherToken.approve(event.address, collateralTokenCount, { from: accounts[buyer] })
         await event.buyAllOutcomes(collateralTokenCount, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(event.address), collateralTokenCount)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(event.address), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
 
-        const outcomeToken1 = Token.at(await event.outcomeTokens(0))
-        const outcomeToken2 = Token.at(await event.outcomeTokens(1))
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), collateralTokenCount)
+        const outcomeToken1 = Token.at(await event.outcomeTokens.call(0))
+        const outcomeToken2 = Token.at(await event.outcomeTokens.call(1))
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         // Sell all outcomes
         await event.sellAllOutcomes(collateralTokenCount, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await etherToken.balanceOf(event.address), 0)
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), 0)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(event.address), 0)
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), 0)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), 0)
     })
 
     it('should buy and verify outcomes', async () => {
@@ -65,25 +65,25 @@ contract('Event', function (accounts) {
         const buyer = 1
         const collateralTokenCount = 10
         await etherToken.deposit({ value: collateralTokenCount, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         await etherToken.approve(event.address, collateralTokenCount, { from: accounts[buyer] })
         await event.buyAllOutcomes(collateralTokenCount, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(event.address), collateralTokenCount)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(event.address), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
 
-        const outcomeToken1 = Token.at(await event.outcomeTokens(0))
-        const outcomeToken2 = Token.at(await event.outcomeTokens(1))
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), collateralTokenCount)
+        const outcomeToken1 = Token.at(await event.outcomeTokens.call(0))
+        const outcomeToken2 = Token.at(await event.outcomeTokens.call(1))
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         // Validate getters
-        assert.equal(await event.getOutcomeCount(), 2)
-        assert.deepEqual(await event.getOutcomeTokens(), [await event.outcomeTokens(0), await event.outcomeTokens(1)])
+        assert.equal(await event.getOutcomeCount.call(), 2)
+        assert.deepEqual(await event.getOutcomeTokens.call(), [await event.outcomeTokens.call(0), await event.outcomeTokens.call(1)])
         //using parseInt and .valueOf because of strictEqual comparison in arrays.deepEqual()
-        const outcomeTokenDistribution = await event.getOutcomeTokenDistribution(accounts[buyer])
+        const outcomeTokenDistribution = await event.getOutcomeTokenDistribution.call(accounts[buyer])
         assert.deepEqual(
-            [parseInt(outcomeTokenDistribution[0].valueOf(), 10), parseInt(outcomeTokenDistribution[1].valueOf(),10)],
+            [parseInt(outcomeTokenDistribution[0].valueOf(), 10), parseInt(outcomeTokenDistribution[1].valueOf(), 10)],
             [collateralTokenCount, collateralTokenCount])
     })
 
@@ -92,35 +92,35 @@ contract('Event', function (accounts) {
         const buyer = 2
         const collateralTokenCount = 10
         await etherToken.deposit({ value: collateralTokenCount, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         await etherToken.approve(event.address, collateralTokenCount, { from: accounts[buyer] })
         await event.buyAllOutcomes(collateralTokenCount, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(event.address), collateralTokenCount)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(event.address), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
 
-        const outcomeToken1 = Token.at(await event.outcomeTokens(0))
-        const outcomeToken2 = Token.at(await event.outcomeTokens(1))
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), collateralTokenCount)
+        const outcomeToken1 = Token.at(await event.outcomeTokens.call(0))
+        const outcomeToken2 = Token.at(await event.outcomeTokens.call(1))
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         //Set outcome in oracle contract
         await oracle.setOutcome(1)
-        assert.equal(await oracle.getOutcome(), 1)
-        assert.equal(await oracle.isOutcomeSet(), true)
+        assert.equal(await oracle.getOutcome.call(), 1)
+        assert.equal(await oracle.isOutcomeSet.call(), true)
 
         //Set outcome in event
         await event.setOutcome()
-        assert.equal(await event.outcome(), 1)
-        assert.equal(await event.isOutcomeSet(),true)
+        assert.equal(await event.outcome.call(), 1)
+        assert.equal(await event.isOutcomeSet.call(),true)
 
         //Redeem winnings for buyer account
         const buyerWinnings = utils.getParamFromTxEvent(
             await event.redeemWinnings({ from: accounts[buyer] }), 'winnings')
         assert.equal(buyerWinnings.valueOf(), collateralTokenCount)
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), 0)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
     })
 
     it('should buy, set, and redeem outcomes for scalar event', async () => {
@@ -132,34 +132,34 @@ contract('Event', function (accounts) {
         const buyer = 3
         const collateralTokenCount = 10
         await etherToken.deposit({ value: collateralTokenCount, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         await etherToken.approve(scalarEvent.address, collateralTokenCount, { from: accounts[buyer] })
         await scalarEvent.buyAllOutcomes(collateralTokenCount, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(scalarEvent.address), collateralTokenCount)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(scalarEvent.address), collateralTokenCount)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
 
         const outcomeToken1 = Token.at(await scalarEvent.outcomeTokens(0))
         const outcomeToken2 = Token.at(await scalarEvent.outcomeTokens(1))
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), collateralTokenCount)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), collateralTokenCount)
 
         //Set outcome in oracle contract
         await oracle.setOutcome(0)
-        assert.equal(await oracle.getOutcome(), 0)
-        assert.equal(await oracle.isOutcomeSet(), true)
+        assert.equal(await oracle.getOutcome.call(), 0)
+        assert.equal(await oracle.isOutcomeSet.call(), true)
 
         //Set outcome in event
         await scalarEvent.setOutcome()
-        assert.equal(await scalarEvent.outcome(), 0)
-        assert.equal(await scalarEvent.isOutcomeSet(), true)
+        assert.equal(await scalarEvent.outcome.call(), 0)
+        assert.equal(await scalarEvent.isOutcomeSet.call(), true)
 
         //Redeem winnings for buyer account
         const buyerWinnings = utils.getParamFromTxEvent(
             await scalarEvent.redeemWinnings({ from: accounts[buyer] }), 'winnings')
         assert.equal(buyerWinnings.valueOf(), collateralTokenCount)
-        assert.equal(await outcomeToken1.balanceOf(accounts[buyer]), 0)
-        assert.equal(await outcomeToken2.balanceOf(accounts[buyer]), 0)
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), collateralTokenCount)
+        assert.equal(await outcomeToken1.balanceOf.call(accounts[buyer]), 0)
+        assert.equal(await outcomeToken2.balanceOf.call(accounts[buyer]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), collateralTokenCount)
     })
 })

--- a/test/javascript/test_market_makers.js
+++ b/test/javascript/test_market_makers.js
@@ -28,7 +28,7 @@ contract('MarketMaker', function(accounts) {
         eventFactory = await EventFactory.deployed()
         centralizedOracleFactory = await CentralizedOracleFactory.deployed()
         standardMarketFactory = await StandardMarketFactory.deployed()
-        lmsrMarketMaker = await LMSRMarketMaker.deployed()
+        lmsrMarketMaker = await LMSRMarketMaker.deployed.call()
         etherToken = await EtherToken.deployed()
     })
 
@@ -56,16 +56,16 @@ contract('MarketMaker', function(accounts) {
         const funding = 1e17
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf(accounts[investor]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
 
         await etherToken.approve(market.address, funding, { from: accounts[investor] })
         await market.fund(funding, { from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf(accounts[investor]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
 
         // User buys all outcomes
         const trader = 1
         const outcome = 1
-        const outcomeToken = Token.at(await event.outcomeTokens(outcome))
+        const outcomeToken = Token.at(await event.outcomeTokens.call(outcome))
         const tokenCount = 1e18
         const loopCount = 10
 
@@ -74,11 +74,11 @@ contract('MarketMaker', function(accounts) {
         await event.buyAllOutcomes(tokenCount * loopCount, { from: accounts[trader] })
 
         // User sells tokens
-        const buyerBalance = await etherToken.balanceOf(accounts[trader])
+        const buyerBalance = await etherToken.balanceOf.call(accounts[trader])
         let profit
         for(let i of _.range(loopCount)) {
             // Calculate profit for selling tokens
-            profit = await lmsrMarketMaker.calcProfit(market.address, outcome, tokenCount)
+            profit = await lmsrMarketMaker.calcProfit.call(market.address, outcome, tokenCount)
             if(profit == 0)
                 break
 
@@ -90,7 +90,7 @@ contract('MarketMaker', function(accounts) {
 
             let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))
             let expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-            let actual = (await lmsrMarketMaker.calcMarginalPrice(market.address, outcome)).div(ONE)
+            let actual = (await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome)).div(ONE)
             assert(
                 isClose(actual, expected),
                 `Marginal price calculation is off for iteration ${i}:\n` +
@@ -103,7 +103,7 @@ contract('MarketMaker', function(accounts) {
         // Selling of tokens is worth less than 1 Wei
         assert.equal(profit, 0)
         // User's Ether balance increased
-        assert.isAbove(await etherToken.balanceOf(accounts[trader]), buyerBalance)
+        assert.isAbove(await etherToken.balanceOf.call(accounts[trader]), buyerBalance)
     })
 
     it('should move price of an outcome to 1 after participants buy lots of that outcome from market maker', async () => {
@@ -131,11 +131,11 @@ contract('MarketMaker', function(accounts) {
 
             // Fund market
             await etherToken.deposit({ value: funding, from: accounts[investor] })
-            assert.equal(await etherToken.balanceOf(accounts[investor]), funding)
+            assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
 
             await etherToken.approve(market.address, funding, { from: accounts[investor] })
             await market.fund(funding, { from: accounts[investor] })
-            assert.equal(await etherToken.balanceOf(accounts[investor]), 0)
+            assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
 
             // User buys ether tokens
             const trader = 1
@@ -147,7 +147,7 @@ contract('MarketMaker', function(accounts) {
             let cost
             for(let i of _.range(loopCount)) {
                 // Calculate profit for selling tokens
-                cost = await lmsrMarketMaker.calcCost(market.address, outcome, tokenCount)
+                cost = await lmsrMarketMaker.calcCost.call(market.address, outcome, tokenCount)
 
                 // Buying tokens
                 await etherToken.approve(market.address, tokenCount, { from: accounts[trader] })
@@ -157,7 +157,7 @@ contract('MarketMaker', function(accounts) {
 
                 let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))
                 let expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-                let actual = (await lmsrMarketMaker.calcMarginalPrice(market.address, outcome)).div(ONE)
+                let actual = (await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome)).div(ONE)
                 assert(
                     isClose(actual, expected) || expected.toString() == 'NaN',
                     `Marginal price calculation is off for iteration ${i}:\n` +

--- a/test/javascript/test_math.js
+++ b/test/javascript/test_math.js
@@ -24,7 +24,7 @@ contract('Math', function () {
 
         for(let x of [1, ONE, MAX_VALUE, randrange(1, MAX_VALUE)].concat(randnums(1, MAX_VALUE, 10))) {
             let X = Decimal(x.valueOf()).div(ONE)
-            let actual = Decimal((await mathLib.ln(x.valueOf())).div(ONE.valueOf()).valueOf())
+            let actual = Decimal((await mathLib.ln.call(x.valueOf())).div(ONE.valueOf()).valueOf())
             let expected = X.ln()
             assert(
                 isClose(actual, expected),
@@ -38,7 +38,7 @@ contract('Math', function () {
         const MIN_POWER = Decimal(1).div(ONE).ln().mul(ONE).floor()
         for(let x of [MAX_SVALUE.neg(), MIN_POWER, 0, MAX_POWER].concat(randnums(MAX_SVALUE.neg(), MAX_POWER, 10))) {
             let X = Decimal(x.valueOf()).div(ONE)
-            let actual = Decimal((await mathLib.exp(x.valueOf())).valueOf()).div(ONE)
+            let actual = Decimal((await mathLib.exp.call(x.valueOf())).valueOf()).div(ONE)
             let expected = X.exp()
             assert(
                 isClose(actual, expected),
@@ -53,7 +53,7 @@ contract('Math', function () {
 
     it('should compute max', async () => {
         for(let seq of _.range(10).map(() => randnums(-100, 100, 10))) {
-            assert.equal((await mathLib.max(seq)).valueOf(), Decimal.max(...seq).valueOf())
+            assert.equal((await mathLib.max.call(seq)).valueOf(), Decimal.max(...seq).valueOf())
         }
     })
 })

--- a/test/javascript/test_oracles.js
+++ b/test/javascript/test_oracles.js
@@ -43,7 +43,7 @@ contract('Oracle', function (accounts) {
         majorityOracleFactory = await MajorityOracleFactory.deployed()
         ultimateOracleFactory = await UltimateOracleFactory.deployed()
         futarchyOracleFactory = await FutarchyOracleFactory.deployed()
-        lmsrMarketMaker = await LMSRMarketMaker.deployed()
+        lmsrMarketMaker = await LMSRMarketMaker.deployed.call()
         etherToken = await EtherToken.deployed()
 
         // ipfs hashes
@@ -74,18 +74,18 @@ contract('Oracle', function (accounts) {
             'centralizedOracle', CentralizedOracle
         )
         // Replace account resolving outcome
-        assert.equal(await centralizedOracle.owner(), accounts[owner1])
+        assert.equal(await centralizedOracle.owner.call(), accounts[owner1])
         await centralizedOracle.replaceOwner(accounts[owner2], {from: accounts[owner1]})
-        assert.equal(await centralizedOracle.owner(), accounts[owner2])
+        assert.equal(await centralizedOracle.owner.call(), accounts[owner2])
 
         // Set outcome
         await utils.assertRejects(centralizedOracle.setOutcome(0, {from: accounts[owner1]}), "owner1 is not the centralized oracle owner")
-        assert.equal(await centralizedOracle.isOutcomeSet(), false)
+        assert.equal(await centralizedOracle.isOutcomeSet.call(), false)
 
         await centralizedOracle.setOutcome(1, {from: accounts[owner2]})
-        assert.equal(await centralizedOracle.isOutcomeSet(), true)
-        assert.equal(await centralizedOracle.getOutcome(), 1)
-        assert.equal(await centralizedOracle.ipfsHash(), ipfsBytes)
+        assert.equal(await centralizedOracle.isOutcomeSet.call(), true)
+        assert.equal(await centralizedOracle.getOutcome.call(), 1)
+        assert.equal(await centralizedOracle.ipfsHash.call(), ipfsBytes)
     })
 
     it('should test difficulty oracle', async () => {
@@ -98,7 +98,7 @@ contract('Oracle', function (accounts) {
 
         // Set outcome
         await utils.assertRejects(difficultyOracle.setOutcome())
-        assert.equal(await difficultyOracle.isOutcomeSet(), false)
+        assert.equal(await difficultyOracle.isOutcomeSet.call(), false)
 
         // TODO: TestRPC difficulty is 0, so these tests won't pass there
 
@@ -106,7 +106,7 @@ contract('Oracle', function (accounts) {
         // await waitUntilBlock(20, targetBlock)
 
         // await difficultyOracle.setOutcome()
-        // assert.equal(await difficultyOracle.isOutcomeSet(), true)
+        // assert.equal(await difficultyOracle.isOutcomeSet.call(), true)
         // assert.isAbove(await difficultyOracle.getOutcome(), 0)
     })
 
@@ -148,7 +148,7 @@ contract('Oracle', function (accounts) {
         )
         const creator = 0
         await etherToken.deposit({ value: funding, from: accounts[creator] })
-        assert.equal(await etherToken.balanceOf(accounts[creator]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[creator]), funding)
 
         await etherToken.approve(futarchyOracle.address, funding, { from: accounts[creator] })
         await futarchyOracle.fund(funding, { from: accounts[creator] })
@@ -161,13 +161,13 @@ contract('Oracle', function (accounts) {
         const outcome = 1
         const tokenCount = 1e15
 
-        const outcomeTokenCost = await lmsrMarketMaker.calcCost(market.address, outcome, tokenCount)
-        let marketfee = await market.calcMarketFee(outcomeTokenCost)
+        const outcomeTokenCost = await lmsrMarketMaker.calcCost.call(market.address, outcome, tokenCount)
+        let marketfee = await market.calcMarketFee.call(outcomeTokenCost)
         const cost = marketfee.add(outcomeTokenCost)
 
         // Buy all outcomes
         await etherToken.deposit({ value: cost, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf(accounts[buyer]), cost.valueOf())
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), cost.valueOf())
         await etherToken.approve(categoricalEvent.address, cost, { from: accounts[buyer] })
         await categoricalEvent.buyAllOutcomes(cost, { from: accounts[buyer] })
 
@@ -185,8 +185,8 @@ contract('Oracle', function (accounts) {
             'set oracle outcome before deadline')
         await wait(deadline)
         await futarchyOracle.setOutcome()
-        assert.equal(await futarchyOracle.isOutcomeSet(), true)
-        assert.equal(await futarchyOracle.getOutcome(), 1)
+        assert.equal(await futarchyOracle.isOutcomeSet.call(), true)
+        assert.equal(await futarchyOracle.getOutcome.call(), 1)
         await categoricalEvent.setOutcome()
 
         // Set winning outcome for scalar events
@@ -199,7 +199,7 @@ contract('Oracle', function (accounts) {
 
         // Close winning market and transfer collateral tokens to creator
         await futarchyOracle.close({ from: accounts[creator] })
-        assert.isAbove(await etherToken.balanceOf(accounts[creator]), funding)
+        assert.isAbove(await etherToken.balanceOf.call(accounts[creator]), funding)
     })
 
     it('should test majority oracle', async () => {
@@ -215,20 +215,20 @@ contract('Oracle', function (accounts) {
         )
 
         // Majority oracle cannot be resolved yet
-        assert.equal(await majorityOracle.isOutcomeSet(), false)
+        assert.equal(await majorityOracle.isOutcomeSet.call(), false)
 
         // Set outcome in first centralized oracle
         await oracles[0].setOutcome(1, { from: accounts[owners[0]] })
 
         // Majority vote is not reached yet
-        assert.equal(await majorityOracle.isOutcomeSet(), false)
+        assert.equal(await majorityOracle.isOutcomeSet.call(), false)
 
         // Set outcome in second centralized oracle
         await oracles[1].setOutcome(1, { from: accounts[owners[1]] })
 
         // // majority vote is reached
-        assert.equal(await majorityOracle.isOutcomeSet(), true)
-        assert.equal(await majorityOracle.getOutcome(), 1)
+        assert.equal(await majorityOracle.isOutcomeSet.call(), true)
+        assert.equal(await majorityOracle.getOutcome.call(), 1)
     })
 
     // TODO: test signed message oracle
@@ -248,12 +248,12 @@ contract('Oracle', function (accounts) {
 
         // Set outcome in central oracle
         await centralizedOracle.setOutcome(1)
-        assert.equal(await centralizedOracle.getOutcome(), 1)
+        assert.equal(await centralizedOracle.getOutcome.call(), 1)
 
         // Set outcome in ultimate oracle
         await ultimateOracle.setForwardedOutcome()
-        assert.equal(await ultimateOracle.forwardedOutcome(), 1)
-        assert.equal(await ultimateOracle.isOutcomeSet(), false)
+        assert.equal(await ultimateOracle.forwardedOutcome.call(), 1)
+        assert.equal(await ultimateOracle.isOutcomeSet.call(), false)
 
         // Challenge outcome
         const sender1 = 0
@@ -265,20 +265,20 @@ contract('Oracle', function (accounts) {
         await etherToken.deposit({value: 50, from: accounts[sender1]})
         await etherToken.approve(ultimateOracle.address, 50, { from: accounts[sender1] })
         await ultimateOracle.voteForOutcome(2, 50, { from: accounts[sender1] })
-        assert.equal(await ultimateOracle.outcomeAmounts(accounts[sender1], 2), 100)
+        assert.equal(await ultimateOracle.outcomeAmounts.call(accounts[sender1], 2), 100)
 
         // Sender 2 overbids sender 1
         const sender2 = 1
         await etherToken.deposit({value: 150, from: accounts[sender2]})
         await etherToken.approve(ultimateOracle.address, 150, { from: accounts[sender2] })
         await ultimateOracle.voteForOutcome(3, 150, { from: accounts[sender2] })
-        assert.equal(await ultimateOracle.outcomeAmounts(accounts[sender2], 3), 150)
+        assert.equal(await ultimateOracle.outcomeAmounts.call(accounts[sender2], 3), 150)
 
         // Sender 2 tries to increase his front runner position by 150 but can only increase it by 50
         await etherToken.deposit({value: 150, from: accounts[sender2]})
         await etherToken.approve(ultimateOracle.address, 150, { from: accounts[sender2] })
         await ultimateOracle.voteForOutcome(3, 150, { from: accounts[sender2] })
-        assert.equal(await ultimateOracle.outcomeAmounts(accounts[sender2], 3), 200)
+        assert.equal(await ultimateOracle.outcomeAmounts.call(accounts[sender2], 3), 200)
 
         // Trying to withdraw before front runner period ends fails
         await utils.assertRejects(
@@ -286,11 +286,11 @@ contract('Oracle', function (accounts) {
             'withdrew before front runner period')
 
         // Wait for front runner period to pass
-        assert.equal(await ultimateOracle.isOutcomeSet(), false)
+        assert.equal(await ultimateOracle.isOutcomeSet.call(), false)
         await wait(frontRunnerPeriod + 1)
-        assert.equal(await ultimateOracle.isOutcomeSet(), true)
+        assert.equal(await ultimateOracle.isOutcomeSet.call(), true)
 
-        assert.equal(await ultimateOracle.getOutcome(), 3)
+        assert.equal(await ultimateOracle.getOutcome.call(), 3)
 
         // Withdraw winnings
         assert.equal(utils.getParamFromTxEvent(
@@ -314,16 +314,16 @@ contract('Oracle', function (accounts) {
 
         // Set outcome in central oracle
         await centralizedOracle.setOutcome(1)
-        assert.equal(await centralizedOracle.getOutcome(), 1)
+        assert.equal(await centralizedOracle.getOutcome.call(), 1)
 
         // Set outcome in ultimate oracle
         await ultimateOracle.setForwardedOutcome()
-        assert.equal(await ultimateOracle.forwardedOutcome(), 1)
-        assert.equal(await ultimateOracle.isOutcomeSet(), false)
+        assert.equal(await ultimateOracle.forwardedOutcome.call(), 1)
+        assert.equal(await ultimateOracle.isOutcomeSet.call(), false)
 
         // Wait for challenge period to pass
         await wait(challengePeriod + 1)
-        assert.equal(await ultimateOracle.isOutcomeSet(), true)
-        assert.equal(await ultimateOracle.getOutcome(), 1)
+        assert.equal(await ultimateOracle.isOutcomeSet.call(), true)
+        assert.equal(await ultimateOracle.getOutcome.call(), 1)
     })
 })

--- a/test/javascript/test_tokens.js
+++ b/test/javascript/test_tokens.js
@@ -10,8 +10,8 @@ contract('HumanFriendlyToken', function () {
 
     it('can be used to get ether token metadata', async () => {
         const humanFriendlyToken = await HumanFriendlyToken.at(etherToken.address)
-        assert.equal('Ether Token', await humanFriendlyToken.name())
-        assert.equal('ETH', await humanFriendlyToken.symbol())
-        assert.equal(18, await humanFriendlyToken.decimals())
+        assert.equal('Ether Token', await humanFriendlyToken.name.call())
+        assert.equal('ETH', await humanFriendlyToken.symbol.call())
+        assert.equal(18, await humanFriendlyToken.decimals.call())
     })
 })


### PR DESCRIPTION
Changeset is because `solidity-coverage` has the following breaking change:

> Important: v0.4.0 targets solidity >= pragma 0.4.18 and introduces a breaking change for projects that rely on Truffle's simplified contract method interface. All constant view or pure methods now need to be explicitly invoked using .call. e.g: