### PR TITLE
Update truffle

### DIFF
--- a/contracts/Events/CategoricalEvent.sol
+++ b/contracts/Events/CategoricalEvent.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Events/Event.sol";
 
 

--- a/contracts/Events/CategoricalEvent.sol
+++ b/contracts/Events/CategoricalEvent.sol
@@ -45,7 +45,7 @@ contract CategoricalEvent is Event {
     /// @return Event hash
     function getEventHash()
         public
-        constant
+        view
         returns (bytes32)
     {
         return keccak256(collateralToken, oracle, outcomeTokens.length);

--- a/contracts/Events/Event.sol
+++ b/contracts/Events/Event.sol
@@ -90,7 +90,7 @@ contract Event {
     /// @return Outcome count
     function getOutcomeCount()
         public
-        constant
+        view
         returns (uint8)
     {
         return uint8(outcomeTokens.length);
@@ -100,7 +100,7 @@ contract Event {
     /// @return Outcome tokens
     function getOutcomeTokens()
         public
-        constant
+        view
         returns (OutcomeToken[])
     {
         return outcomeTokens;
@@ -110,7 +110,7 @@ contract Event {
     /// @return Outcome token distribution
     function getOutcomeTokenDistribution(address owner)
         public
-        constant
+        view
         returns (uint[] outcomeTokenDistribution)
     {
         outcomeTokenDistribution = new uint[](outcomeTokens.length);
@@ -120,7 +120,7 @@ contract Event {
 
     /// @dev Calculates and returns event hash
     /// @return Event hash
-    function getEventHash() public constant returns (bytes32);
+    function getEventHash() public view returns (bytes32);
 
     /// @dev Exchanges sender's winning outcome tokens for collateral tokens
     /// @return Sender's winnings

--- a/contracts/Events/Event.sol
+++ b/contracts/Events/Event.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Tokens/Token.sol";
 import "../Tokens/OutcomeToken.sol";
 import "../Oracles/Oracle.sol";

--- a/contracts/Events/EventFactory.sol
+++ b/contracts/Events/EventFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Events/CategoricalEvent.sol";
 import "../Events/ScalarEvent.sol";
 

--- a/contracts/Events/ScalarEvent.sol
+++ b/contracts/Events/ScalarEvent.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Events/Event.sol";
 
 

--- a/contracts/Events/ScalarEvent.sol
+++ b/contracts/Events/ScalarEvent.sol
@@ -79,7 +79,7 @@ contract ScalarEvent is Event {
     /// @return Event hash
     function getEventHash()
         public
-        constant
+        view
         returns (bytes32)
     {
         return keccak256(collateralToken, oracle, lowerBound, upperBound);

--- a/contracts/MarketMakers/LMSRMarketMaker.sol
+++ b/contracts/MarketMakers/LMSRMarketMaker.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Utils/Math.sol";
 import "../MarketMakers/MarketMaker.sol";
 

--- a/contracts/MarketMakers/LMSRMarketMaker.sol
+++ b/contracts/MarketMakers/LMSRMarketMaker.sol
@@ -24,7 +24,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return Cost
     function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount)
         public
-        constant
+        view
         returns (uint cost)
     {
         require(market.eventContract().getOutcomeCount() > 1);
@@ -59,7 +59,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return Profit
     function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount)
         public
-        constant
+        view
         returns (uint profit)
     {
         require(market.eventContract().getOutcomeCount() > 1);
@@ -85,7 +85,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return Marginal price of an outcome as a fixed point number
     function calcMarginalPrice(Market market, uint8 outcomeTokenIndex)
         public
-        constant
+        view
         returns (uint price)
     {
         require(market.eventContract().getOutcomeCount() > 1);
@@ -110,7 +110,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return Cost level
     function calcCostLevel(int logN, int[] netOutcomeTokensSold, uint funding)
         private
-        constant
+        pure
         returns(int costLevel)
     {
         // The cost function is C = b * log(sum(exp(q/b) for q in quantities)).
@@ -131,7 +131,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return A result structure composed of the sum, the offset used, and the summand associated with the supplied index
     function sumExpOffset(int logN, int[] netOutcomeTokensSold, uint funding, uint8 outcomeIndex)
         private
-        constant
+        pure
         returns (uint sum, int offset, uint outcomeExpTerm)
     {
         // Naive calculation of this causes an overflow
@@ -170,7 +170,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @return Net outcome tokens sold by market
     function getNetOutcomeTokensSold(Market market)
         private
-        constant
+        view
         returns (int[] quantities)
     {
         quantities = new int[](market.eventContract().getOutcomeCount());

--- a/contracts/MarketMakers/MarketMaker.sol
+++ b/contracts/MarketMakers/MarketMaker.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/Market.sol";
 
 

--- a/contracts/MarketMakers/MarketMaker.sol
+++ b/contracts/MarketMakers/MarketMaker.sol
@@ -8,7 +8,7 @@ contract MarketMaker {
     /*
      *  Public functions
      */
-    function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public constant returns (uint);
-    function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public constant returns (uint);
-    function calcMarginalPrice(Market market, uint8 outcomeTokenIndex) public constant returns (uint);
+    function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public view returns (uint);
+    function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public view returns (uint);
+    function calcMarginalPrice(Market market, uint8 outcomeTokenIndex) public view returns (uint);
 }

--- a/contracts/Markets/Campaign.sol
+++ b/contracts/Markets/Campaign.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Events/Event.sol";
 import "../Markets/StandardMarketFactory.sol";
 import "../Utils/Math.sol";

--- a/contracts/Markets/CampaignFactory.sol
+++ b/contracts/Markets/CampaignFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/Campaign.sol";
 
 

--- a/contracts/Markets/Market.sol
+++ b/contracts/Markets/Market.sol
@@ -43,5 +43,5 @@ contract Market {
     function buy(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint maxCost) public returns (uint);
     function sell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
     function shortSell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
-    function calcMarketFee(uint outcomeTokenCost) public constant returns (uint);
+    function calcMarketFee(uint outcomeTokenCost) public view returns (uint);
 }

--- a/contracts/Markets/Market.sol
+++ b/contracts/Markets/Market.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Events/Event.sol";
 import "../MarketMakers/MarketMaker.sol";
 

--- a/contracts/Markets/StandardMarket.sol
+++ b/contracts/Markets/StandardMarket.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/Market.sol";
 import "../Tokens/Token.sol";
 import "../Events/Event.sol";

--- a/contracts/Markets/StandardMarket.sol
+++ b/contracts/Markets/StandardMarket.sol
@@ -186,7 +186,7 @@ contract StandardMarket is Market {
     /// @return Fee for trade
     function calcMarketFee(uint outcomeTokenCost)
         public
-        constant
+        view
         returns (uint)
     {
         return outcomeTokenCost * fee / FEE_RANGE;

--- a/contracts/Markets/StandardMarketFactory.sol
+++ b/contracts/Markets/StandardMarketFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/StandardMarket.sol";
 
 

--- a/contracts/Markets/StandardMarketWithPriceLogger.sol
+++ b/contracts/Markets/StandardMarketWithPriceLogger.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/StandardMarket.sol";
 
 

--- a/contracts/Markets/StandardMarketWithPriceLogger.sol
+++ b/contracts/Markets/StandardMarketWithPriceLogger.sol
@@ -102,6 +102,7 @@ contract StandardMarketWithPriceLogger is StandardMarket {
     /// @return Average price for long tokens over time
     function getAvgPrice()
         public
+        view
         returns (uint)
     {
         if(endDate > 0)

--- a/contracts/Markets/StandardMarketWithPriceLoggerFactory.sol
+++ b/contracts/Markets/StandardMarketWithPriceLoggerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Markets/StandardMarketWithPriceLogger.sol";
 
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,23 +1,23 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.4.2;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }

--- a/contracts/Oracles/CentralizedOracle.sol
+++ b/contracts/Oracles/CentralizedOracle.sol
@@ -72,7 +72,7 @@ contract CentralizedOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         return isSet;
@@ -82,7 +82,7 @@ contract CentralizedOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         return outcome;

--- a/contracts/Oracles/CentralizedOracle.sol
+++ b/contracts/Oracles/CentralizedOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 
 

--- a/contracts/Oracles/CentralizedOracleFactory.sol
+++ b/contracts/Oracles/CentralizedOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/CentralizedOracle.sol";
 
 

--- a/contracts/Oracles/DifficultyOracle.sol
+++ b/contracts/Oracles/DifficultyOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 
 

--- a/contracts/Oracles/DifficultyOracle.sol
+++ b/contracts/Oracles/DifficultyOracle.sol
@@ -44,7 +44,7 @@ contract DifficultyOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         // Difficulty is always bigger than 0
@@ -55,7 +55,7 @@ contract DifficultyOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         return int(difficulty);

--- a/contracts/Oracles/DifficultyOracleFactory.sol
+++ b/contracts/Oracles/DifficultyOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/DifficultyOracle.sol";
 
 

--- a/contracts/Oracles/FutarchyOracle.sol
+++ b/contracts/Oracles/FutarchyOracle.sol
@@ -154,7 +154,7 @@ contract FutarchyOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         return isSet;
@@ -164,7 +164,7 @@ contract FutarchyOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         return int(winningMarketIndex);

--- a/contracts/Oracles/FutarchyOracle.sol
+++ b/contracts/Oracles/FutarchyOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 import "../Events/EventFactory.sol";
 import "../Markets/StandardMarketWithPriceLoggerFactory.sol";

--- a/contracts/Oracles/FutarchyOracleFactory.sol
+++ b/contracts/Oracles/FutarchyOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/FutarchyOracle.sol";
 
 

--- a/contracts/Oracles/MajorityOracle.sol
+++ b/contracts/Oracles/MajorityOracle.sol
@@ -32,6 +32,7 @@ contract MajorityOracle is Oracle {
     /// @return Outcome
     function getStatusAndOutcome()
         public
+        view
         returns (bool outcomeSet, int outcome)
     {
         uint i;
@@ -69,7 +70,7 @@ contract MajorityOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         var (outcomeSet, ) = getStatusAndOutcome();
@@ -80,7 +81,7 @@ contract MajorityOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         var (, winningOutcome) = getStatusAndOutcome();

--- a/contracts/Oracles/MajorityOracle.sol
+++ b/contracts/Oracles/MajorityOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 
 

--- a/contracts/Oracles/MajorityOracleFactory.sol
+++ b/contracts/Oracles/MajorityOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/MajorityOracle.sol";
 
 

--- a/contracts/Oracles/Oracle.sol
+++ b/contracts/Oracles/Oracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 
 /// @title Abstract oracle contract - Functions to be implemented by oracles

--- a/contracts/Oracles/Oracle.sol
+++ b/contracts/Oracles/Oracle.sol
@@ -4,6 +4,6 @@ pragma solidity 0.4.18;
 /// @title Abstract oracle contract - Functions to be implemented by oracles
 contract Oracle {
 
-    function isOutcomeSet() public constant returns (bool);
-    function getOutcome() public constant returns (int);
+    function isOutcomeSet() public view returns (bool);
+    function getOutcome() public view returns (int);
 }

--- a/contracts/Oracles/SignedMessageOracle.sol
+++ b/contracts/Oracles/SignedMessageOracle.sol
@@ -84,7 +84,7 @@ contract SignedMessageOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         return isSet;
@@ -94,7 +94,7 @@ contract SignedMessageOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         return outcome;

--- a/contracts/Oracles/SignedMessageOracle.sol
+++ b/contracts/Oracles/SignedMessageOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 
 

--- a/contracts/Oracles/SignedMessageOracleFactory.sol
+++ b/contracts/Oracles/SignedMessageOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/SignedMessageOracle.sol";
 
 

--- a/contracts/Oracles/UltimateOracle.sol
+++ b/contracts/Oracles/UltimateOracle.sol
@@ -150,6 +150,7 @@ contract UltimateOracle is Oracle {
     /// @return Is challenge period over?
     function isChallengePeriodOver()
         public
+        view
         returns (bool)
     {
         return forwardedOutcomeSetTimestamp != 0 && now.sub(forwardedOutcomeSetTimestamp) > challengePeriod;
@@ -159,6 +160,7 @@ contract UltimateOracle is Oracle {
     /// @return Is front runner period over?
     function isFrontRunnerPeriodOver()
         public
+        view
         returns (bool)
     {
         return frontRunnerSetTimestamp != 0 && now.sub(frontRunnerSetTimestamp) > frontRunnerPeriod;
@@ -168,6 +170,7 @@ contract UltimateOracle is Oracle {
     /// @return Is challenged?
     function isChallenged()
         public
+        view
         returns (bool)
     {
         return frontRunnerSetTimestamp != 0;
@@ -177,7 +180,7 @@ contract UltimateOracle is Oracle {
     /// @return Is outcome set?
     function isOutcomeSet()
         public
-        constant
+        view
         returns (bool)
     {
         return    isChallengePeriodOver() && !isChallenged()
@@ -188,7 +191,7 @@ contract UltimateOracle is Oracle {
     /// @return Outcome
     function getOutcome()
         public
-        constant
+        view
         returns (int)
     {
         if (isFrontRunnerPeriodOver())

--- a/contracts/Oracles/UltimateOracle.sol
+++ b/contracts/Oracles/UltimateOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/Oracle.sol";
 import "../Tokens/Token.sol";
 import "../Utils/Math.sol";

--- a/contracts/Oracles/UltimateOracleFactory.sol
+++ b/contracts/Oracles/UltimateOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Oracles/UltimateOracle.sol";
 
 

--- a/contracts/Tokens/EtherToken.sol
+++ b/contracts/Tokens/EtherToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Tokens/StandardToken.sol";
 
 

--- a/contracts/Tokens/HumanFriendlyToken.sol
+++ b/contracts/Tokens/HumanFriendlyToken.sol
@@ -1,6 +1,6 @@
 /// Implements ERC 20 Token standard including extra accessors for human readability.
 /// See: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Tokens/Token.sol";
 
 

--- a/contracts/Tokens/HumanFriendlyToken.sol
+++ b/contracts/Tokens/HumanFriendlyToken.sol
@@ -10,7 +10,7 @@ contract HumanFriendlyToken is Token {
     /*
      *  Public functions
      */
-    function name() public constant returns (string);
-    function symbol() public constant returns (string);
-    function decimals() public constant returns (uint8);
+    function name() public view returns (string);
+    function symbol() public view returns (string);
+    function decimals() public view returns (uint8);
 }

--- a/contracts/Tokens/OutcomeToken.sol
+++ b/contracts/Tokens/OutcomeToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Tokens/StandardToken.sol";
 
 

--- a/contracts/Tokens/StandardToken.sol
+++ b/contracts/Tokens/StandardToken.sol
@@ -73,7 +73,7 @@ contract StandardToken is Token {
     /// @return Remaining allowance for spender
     function allowance(address owner, address spender)
         public
-        constant
+        view
         returns (uint)
     {
         return allowances[owner][spender];
@@ -84,7 +84,7 @@ contract StandardToken is Token {
     /// @return Balance of owner
     function balanceOf(address owner)
         public
-        constant
+        view
         returns (uint)
     {
         return balances[owner];
@@ -94,7 +94,7 @@ contract StandardToken is Token {
     /// @return Total supply
     function totalSupply()
         public
-        constant
+        view
         returns (uint)
     {
         return totalTokens;

--- a/contracts/Tokens/StandardToken.sol
+++ b/contracts/Tokens/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 import "../Tokens/Token.sol";
 import "../Utils/Math.sol";
 

--- a/contracts/Tokens/Token.sol
+++ b/contracts/Tokens/Token.sol
@@ -1,5 +1,5 @@
 /// Implements ERC 20 Token standard: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 
 /// @title Abstract token contract - Functions to be implemented by token contracts

--- a/contracts/Tokens/Token.sol
+++ b/contracts/Tokens/Token.sol
@@ -17,7 +17,7 @@ contract Token {
     function transfer(address to, uint value) public returns (bool);
     function transferFrom(address from, address to, uint value) public returns (bool);
     function approve(address spender, uint value) public returns (bool);
-    function balanceOf(address owner) public constant returns (uint);
-    function allowance(address owner, address spender) public constant returns (uint);
-    function totalSupply() public constant returns (uint);
+    function balanceOf(address owner) public view returns (uint);
+    function allowance(address owner, address spender) public view returns (uint);
+    function totalSupply() public view returns (uint);
 }

--- a/contracts/Utils/Math.sol
+++ b/contracts/Utils/Math.sol
@@ -22,7 +22,7 @@ library Math {
     /// @return e**x
     function exp(int x)
         public
-        constant
+        pure
         returns (uint)
     {
         // revert if x is > MAX_POWER, where
@@ -107,7 +107,7 @@ library Math {
     /// @return ln(x)
     function ln(uint x)
         public
-        constant
+        pure
         returns (int)
     {
         require(x > 0);
@@ -157,7 +157,7 @@ library Math {
     /// @return logarithmic value
     function floorLog2(uint x)
         public
-        constant
+        pure
         returns (int lo)
     {
         lo = -64;
@@ -178,14 +178,14 @@ library Math {
     /// @return Maximum number
     function max(int[] nums)
         public
-        constant
-        returns (int max)
+        pure
+        returns (int maxNum)
     {
         require(nums.length > 0);
-        max = -2**255;
+        maxNum = -2**255;
         for (uint i = 0; i < nums.length; i++)
-            if (nums[i] > max)
-                max = nums[i];
+            if (nums[i] > maxNum)
+                maxNum = nums[i];
     }
 
     /// @dev Returns whether an add operation causes an overflow
@@ -194,7 +194,7 @@ library Math {
     /// @return Did no overflow occur?
     function safeToAdd(uint a, uint b)
         public
-        constant
+        pure
         returns (bool)
     {
         return a + b >= a;
@@ -206,7 +206,7 @@ library Math {
     /// @return Did no underflow occur?
     function safeToSub(uint a, uint b)
         public
-        constant
+        pure
         returns (bool)
     {
         return a >= b;
@@ -218,7 +218,7 @@ library Math {
     /// @return Did no overflow occur?
     function safeToMul(uint a, uint b)
         public
-        constant
+        pure
         returns (bool)
     {
         return b == 0 || a * b / b == a;
@@ -230,7 +230,7 @@ library Math {
     /// @return Sum
     function add(uint a, uint b)
         public
-        constant
+        pure
         returns (uint)
     {
         require(safeToAdd(a, b));
@@ -243,7 +243,7 @@ library Math {
     /// @return Difference
     function sub(uint a, uint b)
         public
-        constant
+        pure
         returns (uint)
     {
         require(safeToSub(a, b));
@@ -256,7 +256,7 @@ library Math {
     /// @return Product
     function mul(uint a, uint b)
         public
-        constant
+        pure
         returns (uint)
     {
         require(safeToMul(a, b));
@@ -269,7 +269,7 @@ library Math {
     /// @return Did no overflow occur?
     function safeToAdd(int a, int b)
         public
-        constant
+        pure
         returns (bool)
     {
         return (b >= 0 && a + b >= a) || (b < 0 && a + b < a);
@@ -281,7 +281,7 @@ library Math {
     /// @return Did no underflow occur?
     function safeToSub(int a, int b)
         public
-        constant
+        pure
         returns (bool)
     {
         return (b >= 0 && a - b <= a) || (b < 0 && a - b > a);
@@ -293,7 +293,7 @@ library Math {
     /// @return Did no overflow occur?
     function safeToMul(int a, int b)
         public
-        constant
+        pure
         returns (bool)
     {
         return (b == 0) || (a * b / b == a);
@@ -305,7 +305,7 @@ library Math {
     /// @return Sum
     function add(int a, int b)
         public
-        constant
+        pure
         returns (int)
     {
         require(safeToAdd(a, b));
@@ -318,7 +318,7 @@ library Math {
     /// @return Difference
     function sub(int a, int b)
         public
-        constant
+        pure
         returns (int)
     {
         require(safeToSub(a, b));
@@ -331,7 +331,7 @@ library Math {
     /// @return Product
     function mul(int a, int b)
         public
-        constant
+        pure
         returns (int)
     {
         require(safeToMul(a, b));

--- a/contracts/Utils/Math.sol
+++ b/contracts/Utils/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 
 /// @title Math library - Allows calculation of logarithmic and exponential functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -4257,9 +4257,9 @@
       "dev": true
     },
     "solc": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.15.tgz",
-      "integrity": "sha1-iujxYGoSSj+BwoudzssJZOvfnyU=",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.18.tgz",
+      "integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
       "dev": true,
       "requires": {
         "fs-extra": "0.30.0",
@@ -4517,14 +4517,14 @@
       "dev": true
     },
     "truffle": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-3.4.11.tgz",
-      "integrity": "sha512-DT5nArmVW0wPCPMCHrYyVrhBbTiA2VLTOXIbbHULHTCJSFOSsDK6EDKA2nrtzq3fZ6i++ZS34iIjLNY27dBLXQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.4.tgz",
+      "integrity": "sha512-keAkRNNfU3W7yUMRDF3YHoqmqdv6TChXY0g+RuPpxnRHfspXVtIKwuN2pV07jzY/RbDsIKShcSyF7VBV7eZUvg==",
       "dev": true,
       "requires": {
         "mocha": "3.5.3",
         "original-require": "1.0.1",
-        "solc": "0.4.15"
+        "solc": "0.4.18"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm-prepublish": "^1.2.3",
     "run-with-testrpc": "^0.3.0",
     "solidity-coverage": "^0.4.2",
-    "truffle": "^3.4.11"
+    "truffle": "^4.0.4"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Collection of smart contracts for the Gnosis prediction market platform",
   "scripts": {
     "lint": "eslint .",
+    "develop": "truffle develop",
     "compile": "truffle compile",
     "migrate": "truffle migrate",
     "networks": "truffle networks",

--- a/test/solidity/TestMath.sol
+++ b/test/solidity/TestMath.sol
@@ -5,7 +5,7 @@ import "truffle/DeployedAddresses.sol";
 import "../../contracts/Utils/Math.sol";
 
 contract TestMath {
-    function testMathOverloaded() {
+    function testMathOverloaded() public {
         /* Test Overloaded functions using integers */
 
         //Safe to add int

--- a/test/solidity/TestMath.sol
+++ b/test/solidity/TestMath.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";


### PR DESCRIPTION
Moving to the new Truffle means going to Solc 0.4.18

0.4.18 means converting `constant` function modifiers to `view` and `pure` function modifiers. There are also a few missing `view` and `pure` modifiers that it has caught.

Also, a new command `truffle develop` is available as `npm run develop`