### PR TITLE
Update project references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
     all_branches: true
     tags: true
     node: '7'
-    repo: gnosis/gnosis-contracts
+    repo: gnosis/pm-contracts

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 Gnosis Smart Contracts
 ======================
 
-[![Logo](https://raw.githubusercontent.com/gnosis/gnosis-contracts/master/assets/logo.png)](https://gnosis.pm/)
+[![Logo](https://raw.githubusercontent.com/gnosis/pm-contracts/master/assets/logo.png)](https://gnosis.pm/)
 
-[![Build Status](https://travis-ci.org/gnosis/gnosis-contracts.svg?branch=master)](https://travis-ci.org/gnosis/gnosis-contracts)
+[![Build Status](https://travis-ci.org/gnosis/pm-contracts.svg?branch=master)](https://travis-ci.org/gnosis/pm-contracts)
 
-[![Codecov badge](https://codecov.io/gh/gnosis/gnosis-contracts/branch/master/graph/badge.svg)](https://codecov.io/gh/gnosis/gnosis-contracts/)
+[![Codecov badge](https://codecov.io/gh/gnosis/pm-contracts/branch/master/graph/badge.svg)](https://codecov.io/gh/gnosis/pm-contracts/)
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/gnosis/gnosis-contracts.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/gnosis/pm-contracts.svg)](https://greenkeeper.io/)
 
 [![Slack Status](https://slack.gnosis.pm/badge.svg)](https://slack.gnosis.pm)
 
 Collection of smart contracts for the Gnosis prediction market platform (https://www.gnosis.pm).
-To interact with those contracts have a look at (https://github.com/gnosis/gnosis.js/).
+To interact with those contracts have a look at (https://github.com/gnosis/pm-js/).
 
 Install
 -------
@@ -103,7 +103,7 @@ npm run measuregasstats
 Documentation
 -------------
 
-There is a copy version hosted online at https://gnosis.github.io/gnosis-contracts/
+There is a copy version hosted online at https://gnosis.github.io/pm-contracts/
 
 ### Build docs for readthedocs
 

--- a/docs/source/Makefile
+++ b/docs/source/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = gnosis-contracts
+SPHINXPROJ    = pm-contracts
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ from recommonmark.parser import CommonMarkParser
 
 # -- Project information -----------------------------------------------------
 
-project = 'gnosis-contracts'
+project = 'pm-contracts'
 copyright = '2018, Gnosis'
 author = 'Gnosis'
 
@@ -106,7 +106,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'gnosis-contractsdoc'
+htmlhelp_basename = 'pm-contractsdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -133,7 +133,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'gnosis-contracts.tex', 'gnosis-contracts Documentation',
+    (master_doc, 'pm-contracts.tex', 'pm-contracts Documentation',
      'Gnosis', 'manual'),
 ]
 
@@ -143,7 +143,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'gnosis-contracts', 'gnosis-contracts Documentation',
+    (master_doc, 'pm-contracts', 'pm-contracts Documentation',
      [author], 1)
 ]
 
@@ -154,7 +154,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'gnosis-contracts', 'gnosis-contracts Documentation',
-     author, 'gnosis-contracts', 'One line description of project.',
+    (master_doc, 'pm-contracts', 'pm-contracts Documentation',
+     author, 'pm-contracts', '',
      'Miscellaneous'),
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,7 +70,7 @@ Log gas measurements into `build/gas-stats.json`:
 Documentation
 -------------
 
-There is a copy version hosted online at https://gnosis.github.io/gnosis-contracts/
+There is a copy version hosted online at https://gnosis.github.io/pm-contracts/
 
 Build docs with doxity:
 

--- a/docs/source/make.bat
+++ b/docs/source/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=gnosis-contracts
+set SPHINXPROJ=pm-contracts
 
 if "%1" == "" goto help
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gnosis.pm/gnosis-core-contracts",
+  "name": "@gnosis.pm/pm-contracts",
   "version": "1.0.3",
   "description": "Collection of smart contracts for the Gnosis prediction market platform",
   "scripts": {
@@ -41,10 +41,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gnosis/gnosis-contracts.git"
+    "url": "git+https://github.com/gnosis/pm-contracts.git"
   },
   "bugs": {
-    "url": "https://github.com/gnosis/gnosis-contracts/issues"
+    "url": "https://github.com/gnosis/pm-contracts/issues"
   },
-  "homepage": "https://github.com/gnosis/gnosis-contracts#readme"
+  "homepage": "https://github.com/gnosis/pm-contracts#readme"
 }


### PR DESCRIPTION
Documentation updated to be consistent with the new project names.
- package-lock.json must be updated when the project is renamed.
- The URL of the repo must be changed in ReadTheDocs after renaming it.
